### PR TITLE
Add holodeck-furiosa

### DIFF
--- a/files/sudoers
+++ b/files/sudoers
@@ -1,1 +1,1 @@
-%wheel ALL=(ALL) ALL
+%sudo ALL=(ALL:ALL) ALL

--- a/holodeck-furiosa.toml
+++ b/holodeck-furiosa.toml
@@ -1,0 +1,10 @@
+[package]
+name = "holodeck-furiosa"
+version = "0.1.0"
+release = 1
+description = "configuration of server furiosa"
+requires = [
+    "cron",
+    "curl",
+    "hologram-base",
+]

--- a/holodeck-jarvis.toml
+++ b/holodeck-jarvis.toml
@@ -1,11 +1,11 @@
 [package]
 name = "holodeck-jarvis"
-version = "1.7"
+version = "2.1.0"
 release = 1
 description = "configuration for raspberry pi 'jarvis'"
 requires = [
 	"hologram-dummy", # because holo is not packaged yet for arm
-	"hologram-base",
+	"hologram-base-arch",
 	"wpa_supplicant",
 	"polkit", # for using poweroff etc. without sudo
 ]
@@ -18,7 +18,7 @@ name    = "laerling"
 system  = false
 comment = "Benjamin Ludwig"
 uid     = 1001
-groups  = [ "audio", "video", "wheel" ]
+groups  = [ "audio", "video", "sudo" ]
 home    = "/home/laerling"
 shell   = "/bin/bash"
 

--- a/holodeck-laptop.toml
+++ b/holodeck-laptop.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holodeck-laptop"
-version = "3.0.0"
+version = "3.0.1"
 release = 1
 description = "configuration of laptop"
 requires = [
@@ -19,6 +19,10 @@ requires = [
 
 
 # user
+
+[[group]]
+name = "sudo"
+system = false
 
 [[user]]
 name    = "laerling"

--- a/holodeck-laptop.toml
+++ b/holodeck-laptop.toml
@@ -1,12 +1,12 @@
 [package]
 name = "holodeck-laptop"
-version = "2.0.1"
+version = "3.0.0"
 release = 1
 description = "configuration of laptop"
 requires = [
 	"holo-users-groups",
 
-	"hologram-base",
+	"hologram-base-arch",
 	"hologram-dev",
 	"hologram-multimedia",
 
@@ -25,7 +25,7 @@ name    = "laerling"
 system  = false
 comment = "Benjamin Ludwig"
 uid     = 1000
-groups  = [ "audio", "video", "wheel" ]
+groups  = [ "audio", "video", "sudo" ]
 home    = "/home/laerling"
 shell   = "/bin/bash"
 

--- a/holodeck-laptop.toml
+++ b/holodeck-laptop.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holodeck-laptop"
-version = "3.0.1"
+version = "3.1.0"
 release = 1
 description = "configuration of laptop"
 requires = [
@@ -36,8 +36,8 @@ shell   = "/bin/bash"
 [[directory]]
 path = "/home/laerling"
 mode = "0700"
-owner = 1000
-group = 1000
+owner = "laerling"
+group = "laerling"
 
 
 # screen setup

--- a/hologram-base-arch.toml
+++ b/hologram-base-arch.toml
@@ -1,0 +1,26 @@
+[package]
+name = "hologram-base-arch"
+version = "0.1.0"
+release = 1
+description = "Minimal configuration, specific to Arch Linux"
+requires = [
+    #############################################################
+    # dependencies whose package names exist only in Arch repos #
+    #############################################################
+    "bind-tools", # for host, dig, nslookup
+    "gnu-netcat",
+    "group:base-devel", # don't depend on group:base. It can't be resolved by pacman -Sg
+    "pacman-contrib", # rankmirrors, ...
+    # no yaourt because that can't be installed as root (due to
+    # makepkg), therefore it cannot exist when a holodeck is
+    # installed for the first time
+
+    ##############################################################
+    # dependencies that have the same package name on Arch and   #
+    # Debian, but which I don't need on my debian-based machines #
+    # so far                                                     #
+    ##############################################################
+    "acpi",
+    "cryptsetup",
+    "rsync",
+]

--- a/hologram-base-arch.toml
+++ b/hologram-base-arch.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hologram-base-arch"
-version = "0.1.0"
+version = "0.1.1"
 release = 1
 description = "Minimal configuration, specific to Arch Linux"
 requires = [
@@ -23,4 +23,7 @@ requires = [
     "acpi",
     "cryptsetup",
     "rsync",
+
+    # and of course, hologram-base itself
+    "hologram-base",
 ]

--- a/hologram-base.toml
+++ b/hologram-base.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hologram-base"
-version = "4.0.2"
+version = "4.0.3"
 release = 1
 description = "Minimal configuration for all systems"
 requires = [

--- a/hologram-base.toml
+++ b/hologram-base.toml
@@ -1,25 +1,17 @@
 [package]
 name = "hologram-base"
-version = "3.1.1"
+version = "4.0.0"
 release = 1
-description = "Minimal configuration"
+description = "Minimal configuration for all systems"
 requires = [
-	"holo",
-	"group:base-devel", # don't depend on group:base. It can't be resolved by pacman -Sg
-
 	"acpi",
-	"bind-tools", # for host, dig, nslookup
-	"cryptsetup",
-	# emacs in hologram-dev since it is too big for a minimal installation
-	# intel-ucode in holodecks since it is machine specific
-	"gnu-netcat",
-	"pacman-contrib", # rankmirrors, ...
-	"rsync",
+	"holo",
 	"screen",
 	"tree",
 	"unzip",
 	"vim", # contains gvim
-	# no yaourt because that can't be installed as root (due to makepkg), therefore it cannot exist when a holodeck is installed for the first time
+	# emacs in hologram-dev since it is too big for a minimal installation
+	# intel-ucode/intel-microcode in holodecks since it is machine specific
 ]
 
 
@@ -32,8 +24,3 @@ contentFrom = "files/sudoers"
 path = "/usr/share/holo/files/00-base/etc/bash.bashrc.holoscript"
 mode = "0755"
 contentFrom = "holoscripts/bashrc"
-
-[[file]]
-path = "/etc/modprobe.d/nobeep.conf"
-mode = "0444"
-content = "blacklist pcspkr"

--- a/hologram-base.toml
+++ b/hologram-base.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hologram-base"
-version = "4.0.0"
+version = "4.0.2"
 release = 1
 description = "Minimal configuration for all systems"
 requires = [

--- a/holoscripts/bashrc
+++ b/holoscripts/bashrc
@@ -1,21 +1,18 @@
-#!/usr/bin/bash
+cat;tail --lines=+3 "$0";exit
+# This must stand in the second line of the file. Everything that follows gets written to the destination file verbatim.
 
-# Don't let ~/.bashrc overwrite the settings in bash.bashrc
-rm -f /home/*/.bashrc
-
-# print contents of already existing file
-cat -
-
-# append
-cat <<EOF
+########################################
+# configuration from bashrc.holoscript "
+########################################
 
 # overwrite prompt variable
 promptcolor="yes"
-if [ "\$promptcolor" = "yes" ]; then
-    PS1="\\[\\033[01;32m\\]\\u@\\h\\[\\033[00m\\]:\\[\\033[01;34m\\]\\w\\[\\033[00m\\]\\\$ "
+if [ "$promptcolor" = "yes" ]; then
+    PS1="\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "
 else
-    PS1="\\u@\\h:\\w\\\$ "
+    PS1="\u@\h:\w\$ "
 fi
+
 
 ##aliases
 
@@ -58,7 +55,7 @@ alias gitr='git remote -v'       ; alias gr='git remote -v'
 alias gits='git status'          ; alias gs='git status' # might shadow ghostscript
 # define any as a function so that it can be called without arguments as well
 function any {
-	ps -e | grep "\$1"
+	ps -e | grep "$1"
 }
 
 # editors
@@ -75,13 +72,23 @@ alias music='play ~/Musik'
 export EDITOR='emacs -nw'
 export VISUAL=vim
 
-# colors for less
-export LESS_TERMCAP_mb=$'\e[1;32m'
-export LESS_TERMCAP_md=$'\e[1;32m'
-export LESS_TERMCAP_me=$'\e[0m'
-export LESS_TERMCAP_se=$'\e[0m'
-export LESS_TERMCAP_so=$'\e[01;33m'
-export LESS_TERMCAP_ue=$'\e[0m'
-export LESS_TERMCAP_us=$'\e[1;4;31m'
+## red and green highlighting
+#export LESS_TERMCAP_mb=$'\e[1;32m'
+#export LESS_TERMCAP_md=$'\e[1;32m'
+#export LESS_TERMCAP_me=$'\e[0m'
+#export LESS_TERMCAP_se=$'\e[0m'
+#export LESS_TERMCAP_so=$'\e[01;33m'
+#export LESS_TERMCAP_ue=$'\e[0m'
+#export LESS_TERMCAP_us=$'\e[1;4;31m'
+
+# green and blue highlighting
+export LESS_TERMCAP_mb=$'\E[1;31m'     # begin bold
+export LESS_TERMCAP_md=$'\E[1;36m'     # begin blink
+export LESS_TERMCAP_me=$'\E[0m'        # reset bold/blink
+export LESS_TERMCAP_so=$'\E[01;44;33m' # begin reverse video
+export LESS_TERMCAP_se=$'\E[0m'        # reset reverse video
+export LESS_TERMCAP_us=$'\E[1;32m'     # begin underline
+export LESS_TERMCAP_ue=$'\E[0m'        # reset underline
+export GROFF_NO_SGR=1                  # for konsole and gnome-terminal
 
 EOF

--- a/holoscripts/bashrc
+++ b/holoscripts/bashrc
@@ -1,5 +1,6 @@
-cat;tail --lines=+3 "$0";exit
-# This must stand in the second line of the file. Everything that follows gets written to the destination file verbatim.
+#!/usr/bin/bash
+cat;tail --lines=+4 "$0";exit
+# This must stand in the third line of the file. Everything that follows gets written to the destination file verbatim.
 
 ########################################
 # configuration from bashrc.holoscript "

--- a/holoscripts/bashrc
+++ b/holoscripts/bashrc
@@ -91,5 +91,3 @@ export LESS_TERMCAP_se=$'\E[0m'        # reset reverse video
 export LESS_TERMCAP_us=$'\E[1;32m'     # begin underline
 export LESS_TERMCAP_ue=$'\E[0m'        # reset underline
 export GROFF_NO_SGR=1                  # for konsole and gnome-terminal
-
-EOF


### PR DESCRIPTION
Also:
- Split hologram-base into hologram-base and hologram-base-arch
  This is necessary to account for packages that have a different
  name on Arch Linux than on Debian Linux.
- Rename group wheel to sudo
---
TODO:
- [x] Test new Arch Linux hologram layout
- [ ] Adapt Makefile to make it Arch/Debian agnostic
---
Alternatively: Implement [distribution-dependent assets](https://github.com/holocm/holo-build/issues/6) into holo-build.